### PR TITLE
Scrape 2016 term

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 
 source "https://rubygems.org"
 
-ruby "2.0.0"
+ruby "2.3.1"
 
 gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
 gem "execjs"

--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gem "nokogiri"
 gem "open-uri-cached"
 gem "fuzzy_match"
 gem 'wikidata-client', '~> 0.0.7', require: 'wikidata'
+gem 'field_serializer', git: 'https://github.com/everypolitician/field_serializer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,3 +53,9 @@ DEPENDENCIES
   pry
   scraperwiki!
   wikidata-client (~> 0.0.7)
+
+RUBY VERSION
+   ruby 2.3.1p112
+
+BUNDLED WITH
+   1.13.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,10 @@
 GIT
+  remote: https://github.com/everypolitician/field_serializer
+  revision: 0132c74bbbbf85397ca79937ff11c8f040d9a591
+  specs:
+    field_serializer (0.2.0)
+
+GIT
   remote: https://github.com/openaustralia/scraperwiki-ruby.git
   revision: fc50176812505e463077d5c673d504a6a234aa78
   branch: morph_defaults
@@ -47,6 +53,7 @@ PLATFORMS
 DEPENDENCIES
   colorize
   execjs
+  field_serializer!
   fuzzy_match
   nokogiri
   open-uri-cached

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -40,6 +40,14 @@ class Member
     name_and_party.split('(').first.tidy
   end
 
+  def matai_titles
+    full_name.delete('.')
+             .split(' ')
+             .select do |w|
+      w == w.upcase && w.length > 1
+    end.map(&:capitalize)
+  end
+
   def party_id
     name_and_party.split('(')[-1].delete(')')
   end

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -13,7 +13,7 @@ class Member
   end
 
   field :honorific_prefix do
-    matai_titles.join(' ')
+    matai_titles.join(';')
   end
 
   field :party_id do

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -12,6 +12,10 @@ class Member
     "#{matai_titles.join(' ')} #{name_without_titles}"
   end
 
+  field :other_name do
+    name_without_titles
+  end
+
   field :honorific_prefix do
     matai_titles.join(';')
   end

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -16,6 +16,10 @@ class Member
     name_without_titles
   end
 
+  field :honorific_prefix do
+    full_name.scan(professional_titles).join(' ')
+  end
+
   field :party_id do
     party_id
   end
@@ -45,7 +49,7 @@ class Member
   end
 
   def name_without_titles
-    full_name.split(matai_titles[-1].upcase)[-1].tidy
+    full_name.split(matai_titles[-1].upcase)[-1].gsub(professional_titles,'').tidy
   end
 
   def matai_titles
@@ -54,6 +58,10 @@ class Member
              .select do |w|
       w == w.upcase && w.length > 1
     end.map(&:capitalize)
+  end
+
+  def professional_titles
+    Regexp.union('Dr', 'Prof')
   end
 
   def party_id

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -16,10 +16,6 @@ class Member
     name_without_titles
   end
 
-  field :honorific_prefix do
-    matai_titles.join(';')
-  end
-
   field :party_id do
     party_id
   end

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -9,7 +9,7 @@ class Member
   end
 
   field :name do
-    name_without_titles
+    "#{matai_titles.join(' ')} #{name_without_titles}"
   end
 
   field :honorific_prefix do

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -9,7 +9,7 @@ class Member
   end
 
   field :name do
-    name_and_party.split('(')[0].tidy
+    full_name
   end
 
   field :party_id do
@@ -34,6 +34,10 @@ class Member
 
   def name_and_party
     noko.xpath('td/text()')[1].text
+  end
+
+  def full_name
+    name_and_party.split('(').first.tidy
   end
 
   def party_id

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -1,0 +1,49 @@
+require 'nokogiri'
+require 'field_serializer'
+
+class Member
+  include FieldSerializer
+
+  def initialize(noko)
+    @noko = noko
+  end
+
+  field :name do
+    name_and_party.split('(')[0].tidy
+  end
+
+  field :party_id do
+    party_id
+  end
+
+  field :party_name do
+    party_list[party_id]
+  end
+
+  field :area do
+    noko.xpath('td/text()')[2].text.tidy
+  end
+
+  field :term do
+    16
+  end
+
+  private
+
+  attr_reader :noko
+
+  def name_and_party
+    noko.xpath('td/text()')[1].text
+  end
+
+  def party_id
+    name_and_party.split('(')[-1].delete(')')
+  end
+
+  def party_list
+  {
+    'H' => 'HRPP',
+    'TS' => 'Tautua Samoa'
+  }
+  end
+end

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -12,10 +12,6 @@ class Member
     "#{matai_titles.join(' ')} #{name_without_titles}"
   end
 
-  field :other_name do
-    name_without_titles
-  end
-
   field :honorific_prefix do
     full_name.scan(professional_titles).join(' ')
   end

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -12,6 +12,10 @@ class Member
     full_name
   end
 
+  field :honorific_prefix do
+    matai_titles.join(' ')
+  end
+
   field :party_id do
     party_id
   end

--- a/lib/member.rb
+++ b/lib/member.rb
@@ -9,7 +9,7 @@ class Member
   end
 
   field :name do
-    full_name
+    name_without_titles
   end
 
   field :honorific_prefix do
@@ -42,6 +42,10 @@ class Member
 
   def full_name
     name_and_party.split('(').first.tidy
+  end
+
+  def name_without_titles
+    full_name.split(matai_titles[-1].upcase)[-1].tidy
   end
 
   def matai_titles

--- a/lib/members.rb
+++ b/lib/members.rb
@@ -1,6 +1,7 @@
 require 'nokogiri'
 require 'open-uri/cached'
 require 'field_serializer'
+require_relative 'member'
 OpenURI::Cache.cache_path = '.cache'
 
 class Members
@@ -15,29 +16,14 @@ class Members
   end
 
   def legislature_members
-    noko.xpath('//div[@class="entry"]/table[1]/tbody/tr').map do |a|
-      name_and_party = a.xpath('td/text()')[1].text
-      party_id = name_and_party.split('(')[-1].gsub(')','')
-      data = {
-        name: name_and_party.split('(')[0].tidy,
-        party_id: party_id,
-        party_name: party_list[party_id],
-        area: a.xpath('td/text()')[2].text.tidy,
-        term: 16
-      }
+    noko.xpath('//div[@class="entry"]/table[1]/tbody/tr').map do |row|
+      Member.new(row).to_h
     end
   end
 
   private
 
   attr_reader :url
-
-  def party_list
-    {
-      'H' => 'HRPP',
-      'TS' => 'Tautua Samoa'
-    }
-  end
 
   def noko
     @noko ||= Nokogiri::HTML(open(url).read)

--- a/lib/members.rb
+++ b/lib/members.rb
@@ -1,13 +1,20 @@
 require 'nokogiri'
 require 'open-uri/cached'
+require 'field_serializer'
 OpenURI::Cache.cache_path = '.cache'
 
 class Members
+  include FieldSerializer
+
   def initialize(url)
     @url = url
   end
 
-  def to_a
+  field :members do
+    legislature_members
+  end
+
+  def legislature_members
     noko.xpath('//div[@class="entry"]/table[1]/tbody/tr').map do |a|
       name_and_party = a.xpath('td/text()')[1].text
       party_id = name_and_party.split('(')[-1].gsub(')','')

--- a/lib/members.rb
+++ b/lib/members.rb
@@ -1,0 +1,38 @@
+require 'nokogiri'
+require 'open-uri/cached'
+OpenURI::Cache.cache_path = '.cache'
+
+class Members
+  def initialize(url)
+    @url = url
+  end
+
+  def to_a
+    noko.xpath('//div[@class="entry"]/table[1]/tbody/tr').map do |a|
+      name_and_party = a.xpath('td/text()')[1].text
+      party_id = name_and_party.split('(')[-1].gsub(')','')
+      data = {
+        name: name_and_party.split('(')[0].tidy,
+        party_id: party_id,
+        party_name: party_list[party_id],
+        area: a.xpath('td/text()')[2].text.tidy,
+        term: 16
+      }
+    end
+  end
+
+  private
+
+  attr_reader :url
+
+  def party_list
+    {
+      'H' => 'HRPP',
+      'TS' => 'Tautua Samoa'
+    }
+  end
+
+  def noko
+    @noko ||= Nokogiri::HTML(open(url).read)
+  end
+end

--- a/lib/members.rb
+++ b/lib/members.rb
@@ -7,8 +7,8 @@ OpenURI::Cache.cache_path = '.cache'
 class Members
   include FieldSerializer
 
-  def initialize(url)
-    @url = url
+  def initialize(noko)
+    @noko = noko
   end
 
   field :members do
@@ -23,9 +23,6 @@ class Members
 
   private
 
-  attr_reader :url
+  attr_reader :noko
 
-  def noko
-    @noko ||= Nokogiri::HTML(open(url).read)
-  end
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,13 +23,22 @@ def scrape_list(url)
   noko = noko_for(url)
   noko.xpath('//div[@class="entry"]/table[1]/tbody/tr').each do |a|
     name_and_party = a.xpath('td/text()')[1].text
-    data = { 
+    party_id = name_and_party.match(/\(([A-Z]+)/)[1].tidy
+    data = {
       name: name_and_party.split('(')[0].tidy,
-      party: name_and_party.match(/\(([A-Z]+)/)[1].tidy,
+      party_id: party_id,
+      party_name: party_list[party_id],
       area: a.xpath('td/text()')[2].text.tidy
     }
     ScraperWiki.save_sqlite([:name], data)
   end
+end
+
+def party_list
+  {
+    'H' => 'HRPP',
+    'TS' => 'Tautua Samoa'
+  }
 end
 
 scrape_list('http://www.palemene.ws/new/members-of-parliament/members-of-the-xvi-parliament/')

--- a/scraper.rb
+++ b/scraper.rb
@@ -14,6 +14,6 @@ end
 
 URL = 'http://www.palemene.ws/new/members-of-parliament/members-of-the-xvi-parliament/'.freeze
 
-Members.new(URL).to_a.each do |member|
+Members.new(URL).to_h[:members].each do |member|
   ScraperWiki.save_sqlite([:name], member)
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -2,11 +2,9 @@
 # encoding: utf-8
 
 require 'scraperwiki'
-require 'nokogiri'
 require 'colorize'
+require_relative 'lib/members'
 require 'pry'
-require 'open-uri/cached'
-OpenURI::Cache.cache_path = '.cache'
 
 class String
   def tidy
@@ -14,32 +12,8 @@ class String
   end
 end
 
-def noko_for(url)
-  Nokogiri::HTML(open(url).read)
-end
+URL = 'http://www.palemene.ws/new/members-of-parliament/members-of-the-xvi-parliament/'.freeze
 
-def scrape_list(url)
-  warn url
-  noko = noko_for(url)
-  noko.xpath('//div[@class="entry"]/table[1]/tbody/tr').each do |a|
-    name_and_party = a.xpath('td/text()')[1].text
-    party_id = name_and_party.split('(')[-1].gsub(')','')
-    data = {
-      name: name_and_party.split('(')[0].tidy,
-      party_id: party_id,
-      party_name: party_list[party_id],
-      area: a.xpath('td/text()')[2].text.tidy,
-      term: 16
-    }
-    ScraperWiki.save_sqlite([:name], data)
-  end
+Members.new(URL).to_a.each do |member|
+  ScraperWiki.save_sqlite([:name], member)
 end
-
-def party_list
-  {
-    'H' => 'HRPP',
-    'TS' => 'Tautua Samoa'
-  }
-end
-
-scrape_list('http://www.palemene.ws/new/members-of-parliament/members-of-the-xvi-parliament/')

--- a/scraper.rb
+++ b/scraper.rb
@@ -18,9 +18,6 @@ def noko_for(url)
   Nokogiri::HTML(open(url).read)
 end
 
-def name_and_id(str)
-end
-
 def scrape_list(url)
   warn url
   noko = noko_for(url)

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,7 +23,7 @@ def scrape_list(url)
   noko = noko_for(url)
   noko.xpath('//div[@class="entry"]/table[1]/tbody/tr').each do |a|
     name_and_party = a.xpath('td/text()')[1].text
-    party_id = name_and_party.match(/\(([A-Z]+)/)[1].tidy
+    party_id = name_and_party.split('(')[-1].gsub(')','')
     data = {
       name: name_and_party.split('(')[0].tidy,
       party_id: party_id,

--- a/scraper.rb
+++ b/scraper.rb
@@ -28,7 +28,8 @@ def scrape_list(url)
       name: name_and_party.split('(')[0].tidy,
       party_id: party_id,
       party_name: party_list[party_id],
-      area: a.xpath('td/text()')[2].text.tidy
+      area: a.xpath('td/text()')[2].text.tidy,
+      term: 16
     }
     ScraperWiki.save_sqlite([:name], data)
   end

--- a/scraper.rb
+++ b/scraper.rb
@@ -30,10 +30,6 @@ def scrape_list(url)
     }
     ScraperWiki.save_sqlite([:name], data)
   end
-
-  unless (next_page = noko.css('div.ngg-navigation a.next/@href')).empty?
-    scrape_list(next_page.text) rescue binding.pry
-  end
 end
 
 scrape_list('http://www.palemene.ws/new/members-of-parliament/members-of-the-xvi-parliament/')

--- a/scraper.rb
+++ b/scraper.rb
@@ -35,4 +35,4 @@ def scrape_list(url)
   end
 end
 
-scrape_list('http://www.parliament.gov.ws/new/members-of-parliament/member/')
+scrape_list('http://www.palemene.ws/new/members-of-parliament/members-of-the-xvi-parliament/')

--- a/scraper.rb
+++ b/scraper.rb
@@ -13,7 +13,8 @@ class String
 end
 
 URL = 'http://www.palemene.ws/new/members-of-parliament/members-of-the-xvi-parliament/'.freeze
+NOKO = Nokogiri::HTML(open(URL).read)
 
-Members.new(URL).to_h[:members].each do |member|
+Members.new(NOKO).to_h[:members].each do |member|
   ScraperWiki.save_sqlite([:name], member)
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -13,7 +13,11 @@ class String
 end
 
 URL = 'http://www.palemene.ws/new/members-of-parliament/members-of-the-xvi-parliament/'.freeze
-NOKO = Nokogiri::HTML(open(URL).read)
+# We need to tweak the document slightly as the trible names of one member are
+# not capitalized in the same way as the trible names of other members. We're doing this now
+# to avoid complications later
+BODY = open(URL).read.gsub('Fatialofa Lupesoliai Tuilaepa', 'FATIALOFA LUPESOLIAI TUILAEPA')
+NOKO = Nokogiri::HTML(BODY)
 
 Members.new(NOKO).to_h[:members].each do |member|
   ScraperWiki.save_sqlite([:name], member)

--- a/scraper.rb
+++ b/scraper.rb
@@ -18,16 +18,20 @@ def noko_for(url)
   Nokogiri::HTML(open(url).read)
 end
 
+def name_and_id(str)
+end
+
 def scrape_list(url)
   warn url
   noko = noko_for(url)
-  noko.css('div.ngg-gallery-thumbnail a').each do |a|
+  noko.xpath('//div[@class="entry"]/table[1]/tbody/tr').each do |a|
+    name_and_party = a.xpath('td/text()')[1].text
     data = { 
-      id: a.attr('data-image-id'),
-      name: a.attr('data-title'),
-      image: a.attr('data-src'),
+      name: name_and_party.split('(')[0].tidy,
+      party: name_and_party.match(/\(([A-Z]+)/)[1].tidy,
+      area: a.xpath('td/text()')[2].text.tidy
     }
-    ScraperWiki.save_sqlite([:id, :name], data)
+    ScraperWiki.save_sqlite([:name], data)
   end
 
   unless (next_page = noko.css('div.ngg-navigation a.next/@href')).empty?


### PR DESCRIPTION
New term data is available on the webpage.

The data types and layout differs from the previous term. 

The member list is presented in a single table. It gives data for name, district and party.

Source: http://www.palemene.ws/new/members-of-parliament/members-of-the-xvi-parliament/
## New data (scraper)
- [x] scraper gets current (i.e. new term's) members (are they _really_ the current members?)
- [x] new term data has correct term set
- [x] fields that are no longer being populated are explained/justified
- [x] new fields that are available are being picked up
- [x] names are in same format as previous term *
- [x] quantities seem sensible (how many politicians _should_ be in this house?)

\* The names are composed as follows: _<tribal names> + <fore and surnames>_ Tribal names are in all caps on the source site. There are differences compared to the live EP data. For example, EP lists the PM as: Tuilaepa Sailele Malielegaoi (this is how wikipedia lists him), though the source site lists him as: 'Auelua Fatialofa Lupesoliai Tuilaepa Dr Sailele Malielegaoi' (His tribal names are: Auelua Fatialofa Lupesoliai Tuilaepa)

All members have tribal names. A person with a tribal name is referred to by their tribal name -- as opposed to their birth name. This article refers to this member by his tribal name, although his birth name is John: http://www.samoaobserver.ws/en/09_03_2016/local/3433/Shy-doctor-gets-his-shot.htm

See:
https://en.wikipedia.org/wiki/Fa%27amatai
http://www.daviddfriedman.com/Academic/Course_Pages/Legal_Systems_Very_Different_13/LegalSysPapers2Discuss13/McHenry_The_Samoan_Way.htm

The source site lists member names prefixed with formal terms of address: afioga, tōfā, susuga. These have not been captured. (https://mike.bitrevision.com/samoan/word/search/?s=Susuga)